### PR TITLE
Travis-CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: python
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
-  - "3.5"
-  - "3.6"
+  # Python 3.x not supported yet
+#  - "3.5"
+#  - "3.6"
 install:
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: python
+python:
+  # We don't actually use the Travis Python, but this keeps it organized.
+  - "2.7"
+  - "3.5"
+  - "3.6"
+install:
+  - sudo apt-get update
+  # We do this conditionally because it saves us some downloading if the
+  # version is the same.
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+
+  # Replace dep1 dep2 ... with your dependencies
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy
+  - source activate test-environment
+  - conda install -c omnia pyemma
+  - conda install -c omnia mdtraj
+  - python setup.py install
+
+script:
+  # Your test script goes here
+  - .travis/run.tests

--- a/.travis/run.tests
+++ b/.travis/run.tests
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+# full list:
+#for name in test/test_*.py
+for name in test/test_sugar.py
+do
+  python $name
+done

--- a/test/test_sugar.py
+++ b/test/test_sugar.py
@@ -95,6 +95,11 @@ def test_sugar_4():
     fh.write(stri)
     fh.close()
     assert(filecmp.cmp("%s/sugar_04.test.dat" % outdir,"%s/sugar_04.test.dat" % refdir)==True)
+
+test_sugar_1()
+test_sugar_2()
+test_sugar_3()
+test_sugar_4()
         
 
 


### PR DESCRIPTION
@sbottaro I also added back travis-ci support.

- Travis.yml files is adapted from [here](https://conda.io/docs/user-guide/tasks/use-conda-with-travis-ci.html).
- Script test/test_sugar.py in order to run one test.
- Bash script .travis/run.tests should be changed to run all tests.
- Extra branch `travis-fail` (not to be merged) has a [failing test](https://travis-ci.org/srnas/barnaba/builds/331201742).

Once Python 3 will be supported, it will be sufficient to uncomment the correct lines from .travis.yml.


Giovanni
