### PR TITLE
ENM fix: cutoff was not passed from command line

### DIFF
--- a/bin/baRNAba.py
+++ b/bin/baRNAba.py
@@ -502,7 +502,7 @@ def enm(args):
         if("B" in args.type):
             sele.append("C2")
 
-    net = enm.Enm(args.pdbs,sele_atoms=sele)
+    net = enm.Enm(args.pdbs,sele_atoms=sele,cutoff=args.cutoff)
 
     # print eigenvectors 
     eigvecs = net.print_evec(args.ntop)


### PR DESCRIPTION
@sbottaro can you also double check the default cutoff?

From the attempts I made it looks like it is in nm. So, the default value when using the python class does not make sense
````
class Enm:

    def __init__(self,pdb,sele_atoms,cutoff=8.0):
````
