### PR TITLE
Allow zero eigenvalues in ENMs

### DIFF
--- a/barnaba/enm.py
+++ b/barnaba/enm.py
@@ -225,8 +225,9 @@ class Enm:
         stri = ""
         # write eigenvectors (skip first 6)
         for i in range(6,ntop+6):
-            # check eigenvalue to be nonzero
-            assert(self.e_val[i] > definitions.tol)
+            if(self.e_val[i] < definitions.tol):
+               stri += "# skipping eigenvector %d (eigenvalue = %f )\n" % (i,self.e_val[i])
+               continue
             stri += "# eigenvector %d \n" % (i) 
             stri += "# beads index & x-component & y-component & z-component \n"
             


### PR DESCRIPTION
Notice that even when there are zero eigenvalues the SHAPE reactivity
is well defined. In particular, I am considering now RNA-protein complexes
where the protein has a soft tail. Reactivity for RNA part comes out correct
(I mean: very similar to the one that I get with a larger cutoff)