### PR TITLE
Added ENM with SBP+C-alpha

### DIFF
--- a/bin/baRNAba.py
+++ b/bin/baRNAba.py
@@ -144,7 +144,7 @@ def parse():
     parser_10.add_argument("--pdb", dest="pdbs",help="PDB file",default=None,required=True)
 
     parser_10.add_argument("--cutoff", dest="cutoff",help="Cutoff distance in nm (default=0.9)",default=0.9,type=float)
-    parser_10.add_argument("--type", dest="type",default='SBP',choices=['P','S','B','SB','SP','BP','SBP','AA'], help='Type of ENM (default=SBP)')    
+    parser_10.add_argument("--type", dest="type",default='SBP',choices=['P','S','B','SB','SP','BP','SBP','SBPC','AA'], help='Type of ENM (default=SBP)')
     parser_10.add_argument("--ntop", dest="ntop",help="Number of top eigenvectors to write (default=10)",default=10,type=int)
     parser_10.add_argument("--sparse", dest="sparse",help="Use sparse matrix diagonalization algorithm. Recomended for large matrices.",action='store_true',default=False)
 
@@ -503,6 +503,8 @@ def enm(args):
             sele.append("C1\'")
         if("B" in args.type):
             sele.append("C2")
+        if("C" in args.type):
+            sele.append("CA")
 
     net = enm.Enm(args.pdbs,sele_atoms=sele,sparse=args.sparse,ntop=args.ntop,cutoff=args.cutoff)
 


### PR DESCRIPTION
On this I am not sure, so please check before merging.

I added an extra ENM type (`SBPC`) which also includes `CA` for proteins. I am using it for a RNA-protein complex (although the new sparse option is really fast, so perhaps I should stop using these coarser models...).

Possible alternatives:
- Always include `CA` by default in the `SBP` model. I think this was the idea of the original paper (to have a cutoff compatible with `CA` in proteins).
- Allow other combinations (e.g. `--type SC`), currently not listed

@giopina @sbottaro What do you think?

