### PR TITLE
Fixed ENM for proteins

### DIFF
--- a/barnaba/enm.py
+++ b/barnaba/enm.py
@@ -35,12 +35,12 @@ class Enm:
      parameters
     ------------
     pdb        : mdtraj trajectory object (TODO: what happens with multiple frames?)
-    sele_atoms : atoms to use as beads (default=["C1\'","C2","P"])
+    sele_atoms : atoms to use as beads (default=["C1\'","C2","P","CA","CB"])
     cutoff     : cutoff radius in nm (default=0.9)
     sparse     : whether or not to use sparse matrices in the diagonalization (default=False)
     ntop       : number of eigenvectors to print, excluding the ones corresponding to null eigenvalues (default=10)
     '''
-    def __init__(self,pdb,sele_atoms=["C1\'","C2","P"],cutoff=0.9,sparse=False,ntop=10):
+    def __init__(self,pdb,sele_atoms=["C1\'","C2","P","CA","CB"],cutoff=0.9,sparse=False,ntop=10):
         self.sparse=sparse
         cur_pdb = md.load_pdb(pdb)
         topology = cur_pdb.topology

--- a/bin/baRNAba.py
+++ b/bin/baRNAba.py
@@ -497,12 +497,15 @@ def enm(args):
         sele = "AA"
     else:
         sele = []
+        sele.append("CA")
         if("P" in args.type):
             sele.append("P")
         if("S" in args.type):
             sele.append("C1\'")
         if("B" in args.type):
             sele.append("C2")
+        if(args.type=="SBP"):
+            sele.append("CB")
 
     net = enm.Enm(args.pdbs,sele_atoms=sele,sparse=args.sparse,ntop=args.ntop,cutoff=args.cutoff)
 


### PR DESCRIPTION
(see #9)

- `SBP` model now includes `CA`+`CB`
- Other models (1 or 2 beads): include `CA` only
- default types in python interface changed so as to include CA and CB

@giopina is this ok?