### PR TITLE
Raise exceptions instead of sys.exit

### DIFF
--- a/barnaba/functions.py
+++ b/barnaba/functions.py
@@ -237,8 +237,7 @@ def rmsd_traj(reference,traj,out=None,heavy_atom=False):
     assert(len(nn_traj.ok_residues)==len(nn_ref.ok_residues))    
     # check that sequence is identical when using heavy atoms
     if(nn_traj.rna_seq_id!=nn_ref.rna_seq_id and heavy_atom==True):
-        sys.stderr.write("# Sequences are not identical, cannot superimpose using all heavy atoms. ")
-        sys.exit(1)
+        raise ValueError("Sequences are not identical, cannot superimpose using all heavy atoms.")
         
     # loop over residues and find common heavy atoms
     idx_ref = []
@@ -272,9 +271,7 @@ def rmsd_traj(reference,traj,out=None,heavy_atom=False):
     print("# found ",len(idx_ref), "atoms in common")
     
     if(len(idx_ref)<3):
-        warn =  "# Only  %d atoms in common. abort.\n" % len(idx_ref)
-        sys.stderr.write(warn)
-        sys.exit(1)
+        raise ValueError("Only %d atoms in common." % len(idx_ref))
         
     traj.superpose(reference,atom_indices=idx_target, ref_atom_indices=idx_ref)
     if(out!=None): traj.save(out)
@@ -334,11 +331,8 @@ def backbone_angles_traj(traj,residues=None,angles=None):
             if(angles[i] in definitions.bb_angles):
                 idx_angles.append(definitions.bb_angles.index(angles[i]))
             else:
-                msg = "# Fatal error. requested angle \"%s\" not available.\n" % angles[i]
-                msg += "# Choose from: %s \n" % definitions.bb_angles
-                sys.stderr.write(msg)
-                sys.exit(1)
-   
+                raise ValueError("Requested angle '%s' not available. Choose from: %s." % 
+                                 (angles[i], definitions.bb_angles))
 
     idxs = (all_idx[:,idx_angles,:]).reshape(-1,4)
     missing = np.where(np.sum(idxs,axis=1)==0)
@@ -403,10 +397,9 @@ def sugar_angles_traj(traj,residues=None,angles=None):
             if(angles[i] in definitions.sugar_angles):
                 idx_angles.append(definitions.sugar_angles.index(angles[i]))
             else:
-                msg = "# Fatal error. requested angle \"%s\" not available.\n" % angles[i]
-                msg += "# Choose from: %s \n" % (definitions.sugar_angles)
-                sys.stderr.write(msg)
-                sys.exit(1)
+                raise ValueError("Requested angle '%s' not available. Choose from: %s." % 
+                                 (angles[i], definitions.sugar_angles))
+
 
     idxs = (all_idx[:,idx_angles,:]).reshape(-1,4)
     missing = np.where(np.sum(idxs,axis=1)==0)
@@ -543,10 +536,10 @@ def jcouplings_traj(traj,residues=None,couplings=None,raw=False):
                 idx_angles.append(definitions.couplings_idx[couplings[i]])
                 idx_angles1.append(i)
             else:
-                msg = "# Fatal error. requested coupling \"%s\" not available.\n" % couplings[i]
-                msg += "# Choose from: %s \n" % definitions.couplings_idx
-                sys.stderr.write(msg)
-                sys.exit(1)
+                raise ValueError("Requested coupling '%s' not available. Choose from: %s." % 
+                                 (couplings[i], definitions.couplings_idx))
+
+                
    
     idxs = (all_idx[:,idx_angles,:]).reshape(-1,4)
     missing = np.where(np.sum(idxs,axis=1)==0)
@@ -1298,7 +1291,7 @@ def parse_dotbracket(threshold, file, weights):
                 if len(dotbr) != len(sequence):
                     print(mult_chain)
                     if not mult_chain:
-                        sys.exit("Dot-bracket length does not match sequence length")
+                        raise ValueError("Dot-bracket length does not match sequence length.")
                     else:
                         dotbr = dotbr[:len(sequence)]
                 base_pairs = parse_dotbr(dotbr)
@@ -1316,7 +1309,7 @@ def parse_dotbracket(threshold, file, weights):
                     dotbr = l[1]
                     if len(dotbr) != len(sequence):
                         if not mult_chain:
-                            sys.exit("Dot-bracket length does not match sequence length")    
+                            raise ValueError("Dot-bracket length does not match sequence length.")
                         else:
                             dotbr = dotbr[:len(sequence)]
                     n_frames += 1
@@ -1337,7 +1330,7 @@ def parse_dotbracket(threshold, file, weights):
                             else:    
                                 ann_list[bp[0], bp[1], "WCc"] += weights[n_frames-1]
     if len(list_base_pairs) == 0:
-        sys.exit("No basepairs found.")
+        raise ValueError("No basepairs found.")
     if traj:
         for ann, value in ann_list.items():
             if len(weights) == 0:

--- a/barnaba/kde.py
+++ b/barnaba/kde.py
@@ -239,7 +239,7 @@ class gaussian_kde(object):
                     self.d)
                 raise ValueError(msg)
 
-        result = zeros((m,), dtype=np.float)
+        result = zeros((m,), dtype=float)
 
         if m >= self.n:
             # there are more points than data, so loop over data

--- a/barnaba/model.py
+++ b/barnaba/model.py
@@ -29,8 +29,7 @@ class Model:
 
         ll = len(data)
         if(ll==0):
-            sys.stderr.write("# Fatal error. No valid residues in pdb file \n")
-            sys.exit(1)
+            raise ValueError("No valid residues in pdb file.")
 
         # array with all coordinates
         self.coords = np.array([data[i][5:8] for i in range(ll)])

--- a/barnaba/nucleic.py
+++ b/barnaba/nucleic.py
@@ -81,9 +81,7 @@ class Nucleic:
         self.indeces_lcs = np.asarray(indeces_lcs).T
 
         if(len(self.ok_residues)<1):
-            warn = "# Only %d  found in structure. Exiting \n" % len(self.ok_residues) 
-            sys.stderr.write(warn)
-            sys.exit(1)
+            raise ValueError("Only %d found in structure." % len(self.ok_residues))
         #else:
         #    warn = "# %d nucleotides found in structure \n" % len(ok_residues) 
         #    sys.stderr.write(warn)
@@ -101,10 +99,8 @@ class Nucleic:
                 if(residues[k] in self.rna_seq):
                     idx_residues.append((self.rna_seq).index(residues[k]))
                 else:
-                    msg = "# Fatal error. Residue \"%s\" not found \n" % residues[k]
-                    msg += "# The list of residues is: %s \n" % self.rna_seq
-                    sys.stderr.write(msg)
-                    sys.exit(1)
+                    raise ValueError("Residue '%s' not found. The list of residues is: %s" %
+                                     (residues[k], self.rna_seq))
         else:
             idx_residues = np.arange(ll)
 
@@ -184,10 +180,9 @@ class Nucleic:
                 if(residues[k] in self.rna_seq):
                     idx_residues.append((self.rna_seq).index(residues[k]))
                 else:
-                    msg = "# Fatal error. Residue \"%s\" not found \n" % residues[k]
-                    msg += "# The list of residues is: %s \n" % self.rna_seq
-                    sys.stderr.write(msg)
-                    sys.exit(1)
+                    raise ValueError("Residue '%s' not found. The list of residues is: %s" %
+                                     (residues[k], self.rna_seq))
+
         else:
             idx_residues = np.arange(ll)
 
@@ -230,10 +225,8 @@ class Nucleic:
                 if(residues[k] in self.rna_seq):
                     idx_residues.append((self.rna_seq).index(residues[k]))
                 else:
-                    msg = "# Fatal error. Residue \"%s\" not found \n" % residues[k]
-                    msg += "# The list of residues is: %s \n" % self.rna_seq
-                    sys.stderr.write(msg)
-                    sys.exit(1)
+                    raise ValueError("Residue '%s' not found. The list of residues is: %s" %
+                                     (residues[k], self.rna_seq))
         else:
             idx_residues = np.arange(ll)
 

--- a/barnaba/smm.py
+++ b/barnaba/smm.py
@@ -24,8 +24,7 @@ class SMM:
             print("# Sequence lenght =",slen)
             self.slen = slen
         else:
-            print("# Error - check your gmat file")
-            sys.exit(1)
+            raise ValueError("Check your gmat file")
 
         # calculate distance matrix
         dmat_sq = cdist(gvecs,gvecs,'sqeuclidean')


### PR DESCRIPTION
### Motivation
I got stuck for a little while on a problem with Barnaba while processing a dataset using multiprocessing. Some files caused the program to exit because no valid nucleobase was found. I did not expect this behavior which caused my program to inexplicably stall since sub-processes exited without raising an Exception that I could identify. In my case the problematic piece of code was in the [`Nucleic` constructor](https://github.com/srnas/barnaba/blob/48ac4a9496c68fc48698f65c5e0d9563761681ec/barnaba/nucleic.py#L86). While this is quickly fixable in the caller by explicitly catching `SystemExit` in a `try` block, I suggest Barnaba should raise a `ValueError` to align with python error handling conventions.

### Changes
- This pattern of using `sys.stderr.write` + `sys.exit` is found in many places in the code. I have replaced these occurrences with `ValueError`s in the parts that can be used as modules (aka everywhere except in [commandline.py](https://github.com/srnas/barnaba/blob/48ac4a9496c68fc48698f65c5e0d9563761681ec/barnaba/commandline.py))